### PR TITLE
send_command

### DIFF
--- a/esphome/components/nextion/nextion.cpp
+++ b/esphome/components/nextion/nextion.cpp
@@ -194,6 +194,17 @@ void Nextion::update_all_components() {
   }
 }
 
+bool Nextion::send_command(const char *command) {
+  if ((!this->is_setup() && !this->ignore_is_setup_) || this->is_sleeping())
+    return false;
+
+  if (this->send_command_(command)) {
+    this->add_no_result_to_queue_("send_command");
+    return true;
+  }
+  return false;
+}
+
 bool Nextion::send_command_printf(const char *format, ...) {
   if ((!this->is_setup() && !this->ignore_is_setup_) || this->is_sleeping())
     return false;

--- a/esphome/components/nextion/nextion.h
+++ b/esphome/components/nextion/nextion.h
@@ -904,6 +904,12 @@ class Nextion : public NextionBase, public PollingComponent, public uart::UARTDe
   void set_wait_for_ack(bool wait_for_ack);
 
   /**
+   * Manually send a raw command to the display.
+   * @param command The pcommand, like "page 0"
+   * @return Whether the send was successful.
+   */
+  bool send_command(const char *command);
+  /**
    * Manually send a raw formatted command to the display.
    * @param format The printf-style command format, like "vis %s,0"
    * @param ... The format arguments


### PR DESCRIPTION
This is a simplified version of `send_command_printf` without the `printf` support. Manually send a raw command to the display.
param command The pcommand, like "page 0"
return Whether the send was successful.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
