### PR TITLE
Update adc_sensor.cpp

### DIFF
--- a/esphome/components/adc/adc_sensor.cpp
+++ b/esphome/components/adc/adc_sensor.cpp
@@ -62,7 +62,7 @@ extern "C"
   }
 
   // load characteristics for each attenuation
-  for (int32_t i = 0; i <= ADC_ATTEN_DB_11; i++) {
+  for (int32_t i = 0; i <= ADC_ATTEN_DB_12; i++) {
     auto adc_unit = channel1_ != ADC1_CHANNEL_MAX ? ADC_UNIT_1 : ADC_UNIT_2;
     auto cal_value = esp_adc_cal_characterize(adc_unit, (adc_atten_t) i, ADC_WIDTH_MAX_SOC_BITS,
                                               1100,  // default vref
@@ -118,7 +118,7 @@ void ADCSensor::dump_config() {
       case ADC_ATTEN_DB_6:
         ESP_LOGCONFIG(TAG, " Attenuation: 6db");
         break;
-      case ADC_ATTEN_DB_11:
+      case ADC_ATTEN_DB_12:
         ESP_LOGCONFIG(TAG, " Attenuation: 11db");
         break;
       default:  // This is to satisfy the unused ADC_ATTEN_MAX
@@ -186,7 +186,7 @@ float ADCSensor::sample() {
   int raw11 = ADC_MAX, raw6 = ADC_MAX, raw2 = ADC_MAX, raw0 = ADC_MAX;
 
   if (channel1_ != ADC1_CHANNEL_MAX) {
-    adc1_config_channel_atten(channel1_, ADC_ATTEN_DB_11);
+    adc1_config_channel_atten(channel1_, ADC_ATTEN_DB_12);
     raw11 = adc1_get_raw(channel1_);
     if (raw11 < ADC_MAX) {
       adc1_config_channel_atten(channel1_, ADC_ATTEN_DB_6);
@@ -201,7 +201,7 @@ float ADCSensor::sample() {
       }
     }
   } else if (channel2_ != ADC2_CHANNEL_MAX) {
-    adc2_config_channel_atten(channel2_, ADC_ATTEN_DB_11);
+    adc2_config_channel_atten(channel2_, ADC_ATTEN_DB_12);
     adc2_get_raw(channel2_, ADC_WIDTH_MAX_SOC_BITS, &raw11);
     if (raw11 < ADC_MAX) {
       adc2_config_channel_atten(channel2_, ADC_ATTEN_DB_6);
@@ -221,7 +221,7 @@ float ADCSensor::sample() {
     return NAN;
   }
 
-  uint32_t mv11 = esp_adc_cal_raw_to_voltage(raw11, &cal_characteristics_[(int32_t) ADC_ATTEN_DB_11]);
+  uint32_t mv11 = esp_adc_cal_raw_to_voltage(raw11, &cal_characteristics_[(int32_t) ADC_ATTEN_DB_12]);
   uint32_t mv6 = esp_adc_cal_raw_to_voltage(raw6, &cal_characteristics_[(int32_t) ADC_ATTEN_DB_6]);
   uint32_t mv2 = esp_adc_cal_raw_to_voltage(raw2, &cal_characteristics_[(int32_t) ADC_ATTEN_DB_2_5]);
   uint32_t mv0 = esp_adc_cal_raw_to_voltage(raw0, &cal_characteristics_[(int32_t) ADC_ATTEN_DB_0]);


### PR DESCRIPTION
I am new at everything, i am trying to set up a NSPanel and i get this error in the setup process: In file included from /data/cache/platformio/packages/framework-espidf/components/driver/include/driver/adc.h:14,
                 from src/esphome/components/adc/adc_sensor.h:10,
                 from src/esphome/components/adc/adc_sensor.cpp:1:
/data/cache/platformio/packages/framework-espidf/components/hal/include/hal/adc_types.h:54:5: note: declared here
     ADC_ATTEN_DB_11 __attribute__((deprecated)) = ADC_ATTEN_DB_12,  ///<This is deprecated, it behaves the same as `ADC_ATTEN_DB_12`

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
